### PR TITLE
AfterPlugin("nadena.dev.modular-avatar") because MA Convert Constraints and MA World Fixed Object creates VRCConstraint

### DIFF
--- a/Packages/dev.hai-vr.resilience.prefabulous.conversions/Scripts/Conversions/Editor/PrefabulousConvertVRCConstraintsToUnityConstraintsPlugin.cs
+++ b/Packages/dev.hai-vr.resilience.prefabulous.conversions/Scripts/Conversions/Editor/PrefabulousConvertVRCConstraintsToUnityConstraintsPlugin.cs
@@ -48,6 +48,10 @@ namespace Prefabulous.Conversions.Shared.Editor
         {
             var converts = context.AvatarRootTransform.GetComponentsInChildren<PrefabulousConvertVRCConstraintsToUnityConstraints>(true);
             if (converts.Length == 0) return;
+            foreach (var convert in converts)
+            {
+                Object.DestroyImmediate(convert);
+            }
 
             var foundConstraints = context.AvatarRootObject.GetComponentsInChildren<Component>(true)
                 .Where(component => component != null) // Unloaded scripts may be null

--- a/Packages/dev.hai-vr.resilience.prefabulous.conversions/Scripts/Conversions/Editor/PrefabulousConvertVRCConstraintsToUnityConstraintsPlugin.cs
+++ b/Packages/dev.hai-vr.resilience.prefabulous.conversions/Scripts/Conversions/Editor/PrefabulousConvertVRCConstraintsToUnityConstraintsPlugin.cs
@@ -39,7 +39,7 @@ namespace Prefabulous.Conversions.Shared.Editor
 
         protected override void Configure()
         {
-            var seq = InPhase(BuildPhase.Transforming);
+            var seq = InPhase(BuildPhase.Transforming).AfterPlugin("nadena.dev.modular-avatar");
             
             seq.Run("Convert VRCConstraints to Unity Constraints", ConvertBackToUnityConstraints);
         }


### PR DESCRIPTION
and destroying components maybe better for CVR etc.
(To reduce missing script issues when converting avatars in Unity 2022 and bringing the prefabs into Unity 2021.)